### PR TITLE
BUGFIX: fixing incompatibility with clang

### DIFF
--- a/actions/context.h
+++ b/actions/context.h
@@ -30,16 +30,16 @@ struct Context {
     struct Expression {
         using FuncType = qrqma::unique_func<Symbol()>;
 
-        Expression(std::type_info const& t, FuncType func) 
+        Expression(std::type_info const& t, FuncType func)
           : mType{t}, mEval{std::move(func)} {}
 
         Expression(Expression&& other) noexcept : mType{std::move(other.mType)}, mEval{std::move(other.mEval)} {}
 
-        template<typename T>
-        T eval() const { return std::any_cast<T>(eval_f()); }
-
         auto eval_f() const { return mEval(); }
         std::type_info const& type() { return mType; }
+
+        template<typename T>
+        T eval() const { return std::any_cast<T>(eval_f()); }
 
     private:
         std::type_info const& mType;
@@ -63,10 +63,10 @@ struct Context {
     void pushExpression(std::type_info const& t, Expression::FuncType f) {
         pushExpression(Expression{t, std::move(f)});
     }
-    
+
     Expression popExpression();
     std::vector<Expression> popAllExpressions();
-    
+
     auto expressionStackSize() const {
         return expression_stack.size();
     }


### PR DESCRIPTION
clang 9.0.1 complains about:

```
actions/context.h:39:50: error: function 'eval_f' with deduced return type cannot be used before it is defined
        T eval() const { return std::any_cast<T>(eval_f()); }
                                                 ^
actions/context.h:41:14: note: 'eval_f' declared here
        auto eval_f() const { return mEval(); }
```

It is unclear to me if this an error in clang or not. (gcc doesn't
complain)

I swapped the two lines to fix this error.